### PR TITLE
Add instructions for pre-loading and point to pre-loaded docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,26 @@ git clone https://github.com/DBCG/connectathon.git
 cd connectathon && git checkout 425795fb8dd39e213140493f22e77880a9257f00
 ```
 
-4. Post the resources desired to be present on the cqf-ruler image:
+4. POST or PUT the resources desired to be present on the cqf-ruler image:
+
+POST will not preserve ids for resources, but PUT will if the id matches the
+resource id in the json.
+
+Use POST for bundles and have PUT in the bundle request, i.e.:
+```
+"request": {
+  "method": "PUT",
+  "url": "Library/library-mat-global-common-functions-FHIR3-2.0.000"
+}
+
+```
+
+Use PUT with matching id for individual resources (see measure directly below).
 
 ```
 # EXM165 Measure
-curl -X POST \
-http://localhost:8080/cqf-ruler-dstu3/fhir/Measure \
+curl -X PUT \
+http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-exm165-FHIR3 \
 -H 'Content-Type: application/json' \
 -d @connectathon/fhir3/resources/measure/measure-EXM165_FHIR3-8.5.000.json
 

--- a/README.md
+++ b/README.md
@@ -89,14 +89,17 @@ http://localhost:8080/cqf-ruler-dstu3/fhir \
 -d @connectathon/fhir3/resources/valuesets/valuesets-EXM165_FHIR3-8.5.000.json
 ```
 
-5. Add the new image to the artifacts repository. Note that this one uses tag
-   0.1.0, which should be different for future iterations.
+5. Commit the changes and add the new image to the artifacts repository. Note
+   that this one uses tag 0.1.1, which should be different for future
+   iterations.
 
 ```
 docker login artifacts.mitre.org:8200
 (Enter Username/Password)
 
-docker tag contentgroup/cqf-ruler artifacts.mitre.org:8200/cqf-ruler-preloaded:0.1.0
+docker commit <CONTAINER_ID> # outputs IMAGE_ID
+
+docker tag <IMAGE_ID> artifacts.mitre.org:8200/cqf-ruler-preloaded:0.1.1
 
 docker push artifacts.mitre.org:8200/cqf-ruler-preloaded
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "4567:4567"
   cqf_ruler:
-    image: contentgroup/cqf-ruler:connectathon22-preloaded
+    image: artifacts.mitre.org:8200/cqf-ruler-preloaded:0.1.0
     ports:
       - "8080:8080"
   ndjson_server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "4567:4567"
   cqf_ruler:
-    image: artifacts.mitre.org:8200/cqf-ruler-preloaded:0.1.0
+    image: artifacts.mitre.org:8200/cqf-ruler-preloaded:0.1.1
     ports:
       - "8080:8080"
   ndjson_server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "4567:4567"
   cqf_ruler:
-    image: artifacts.mitre.org:8200/cqf-ruler-preloaded:0.1.1.no-vs
+    image: artifacts.mitre.org:8200/cqf-ruler-preloaded:0.1.2.no-vs
     ports:
       - "8080:8080"
   ndjson_server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "4567:4567"
   cqf_ruler:
-    image: artifacts.mitre.org:8200/cqf-ruler-preloaded:0.1.1
+    image: artifacts.mitre.org:8200/cqf-ruler-preloaded:0.1.1.no-vs
     ports:
       - "8080:8080"
   ndjson_server:


### PR DESCRIPTION
JIRA Ticket: https://jira.mitre.org/browse/TACOSTRAT-291

Docker Image on Artifactory: https://artifacts.mitre.org/artifactory/webapp/#/artifacts/browse/tree/DockerV2Info/docker/cqf-ruler-preloaded/0.1.1.no-vs

# Summary
`artifacts.mitre.org:8200/cqf-ruler-preloaded:0.1.0` was created with resources for EXM165. Steps taken were added to README.md.

## New behavior
Instead of using `contentgroup/cqf-ruler:connectathon22-preloaded`, cqf_ruler will now use `artifacts.mitre.org:8200/cqf-ruler-preloaded:0.1.0`

## Code changes
Just documentation and docker-compose.yml changes.

# Testing guidance
`docker-compose up --build -d`
Confirm cqf-ruler has the right resources for EXM165.