### PR TITLE
Update tag for deqm-test-client image

### DIFF
--- a/docker-compose-mitre.yml
+++ b/docker-compose-mitre.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   inferno:
-    image: tacoma/deqm-test-client:0.1.1
+    image: tacoma/deqm-test-client:0.2.0
     ports:
       - "4567:4567"
   cqf_ruler:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   inferno:
-    image: tacoma/deqm-test-client:0.1.1
+    image: tacoma/deqm-test-client:0.2.0
     ports:
       - "4567:4567"
   cqf_ruler:


### PR DESCRIPTION
# Summary

Update the compose files to use the [newly published tag](https://hub.docker.com/layers/tacoma/deqm-test-client/0.2.0/images/sha256-089c7a807fefbb3bafca4a3dc49636dde7149520e3e4fe07cff08b0d8dcbb14a) for `deqm-test-client`

## New behavior

Uses 0.2.0 for `deqm-test-client`

## Code changes

Update image tag in both compose files

# Testing guidance

Run `docker-compose up -d --build`. Navigate to http://localhost:4567, and the running Inferno app should have the most recent changes on the `deqm-dev` branch of `deqm-test-client`, I.e. the updated submit-data and value set sequences.
