### PR TITLE
Update tag to 0.2.1 for deqm-test-client image

### DIFF
--- a/docker-compose-mitre.yml
+++ b/docker-compose-mitre.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "4567:4567"
   cqf_ruler:
-    image: tacoma/cqf-ruler-preloaded:0.1.3.no-vs
+    image: tacoma/cqf-ruler-preloaded:0.1.5.no-vs
     ports:
       - "8080:8080"
   ndjson_server:

--- a/docker-compose-mitre.yml
+++ b/docker-compose-mitre.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   inferno:
-    image: tacoma/deqm-test-client:0.2.0
+    image: tacoma/deqm-test-client:0.2.1
     ports:
       - "4567:4567"
   cqf_ruler:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     ports:
       - "4567:4567"
   cqf_ruler:
-    image: tacoma/cqf-ruler-preloaded:0.1.3.no-vs
+    image: tacoma/cqf-ruler-preloaded:0.1.5.no-vs
     ports:
       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   inferno:
-    image: tacoma/deqm-test-client:0.2.0
+    image: tacoma/deqm-test-client:0.2.1
     ports:
       - "4567:4567"
   cqf_ruler:


### PR DESCRIPTION
https://hub.docker.com/layers/tacoma/deqm-test-client/0.2.1/images/sha256-66b526223db27f872b172f623477317eb5b8f4446bcc907c44126ca18d919555