### PR TITLE
Bump version of CQF Ruler preloaded

### DIFF
--- a/docker-compose-mitre.yml
+++ b/docker-compose-mitre.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "4567:4567"
   cqf_ruler:
-    image: tacoma/cqf-ruler-preloaded:0.1.3.no-vs
+    image: tacoma/cqf-ruler-preloaded:0.1.6.no-vs
     ports:
       - "8080:8080"
   ndjson_server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     ports:
       - "4567:4567"
   cqf_ruler:
-    image: tacoma/cqf-ruler-preloaded:0.1.3.no-vs
+    image: tacoma/cqf-ruler-preloaded:0.1.6.no-vs
     ports:
       - "8080:8080"


### PR DESCRIPTION
# Summary
## New behavior
- New version has more mesures (previously only had 124 and 130)
## Code changes
- Just update to the docker compose file
# Testing guidance
- Run `docker-compose up -d`, wait for CQF Ruler to come up, verify that it has measures and libraries
