### PR TITLE
Update deqm-test-client and cqf-ruler tags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,10 @@ version: "3"
 
 services:
   inferno:
-    image: tacoma/deqm-test-client:0.2.0
+    image: tacoma/deqm-test-client:0.3.0
     ports:
       - "4567:4567"
   cqf_ruler:
-    image: tacoma/cqf-ruler-preloaded:0.1.3.no-vs
+    image: tacoma/cqf-ruler-preloaded:0.2.0.no-vs
     ports:
       - "8080:8080"


### PR DESCRIPTION
**NOTE**: This will make #8 and #7 OBE

# Summary

Resolves https://jira.mitre.org/browse/TACOSTRAT-369. The root problem in that was that our cqf-ruler docker image that we pushed to dockerhub did not have a complete Library resource for EXM130, causing the sequence to pass since it thought that that Library had no ValueSet requirements.

## New behavior

* Inferno image is up to date with `deqm-dev`
* cqf-ruler image is up to date with the newest released Measure/Library resources

## Code changes

* Update tags in `docker-compose.yml`

# Testing guidance

* Run `docker-compose up -d --build`
* Once Inferno and cqf-ruler finish booting up, 
  * Enter `http://cqf_ruler:8080/cqf-ruler-dstu3/fhir` for the system under test
  * click "run tests" on the prerequisites tab and select EXM130
* ValueSet sequence should **fail**, since there are no valuesets in the cqf-ruler docker image
