### PR TITLE
Update deqm-test-client tags in docker-compose files

### DIFF
--- a/docker-compose-mitre.yml
+++ b/docker-compose-mitre.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   inferno:
-    image: tacoma/deqm-test-client:0.2.0
+    image: tacoma/deqm-test-client:0.4.0
     ports:
       - "4567:4567"
   cqf_ruler:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   inferno:
-    image: tacoma/deqm-test-client:0.3.0
+    image: tacoma/deqm-test-client:0.4.0
     ports:
       - "4567:4567"
   cqf_ruler:


### PR DESCRIPTION
# Summary
Version bump
## New behavior
 deqm-test-client uses r4 instead of stu3 now

## Code changes
N/A

# Testing guidance
`docker-compose up -d` and verify it's the right version
